### PR TITLE
Should start_time.hour be a string like '00'? I'm having trouble finding...

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ class CalendarHandler(webapp2.RequestHandler):
                 dispevents.append(event)
 
         for showing in dispevents:
-            if showing.start_time.hour is 00:
+            if showing.start_time.hour is '00':
                 showing.start_time = 'TBD'
 
         template_values = {


### PR DESCRIPTION
... examples of what the xml data looks like. One thread suggested that all of the time data would be in a string like:
`startTime='2010-03-13T00:00:00Z'`
http://stackoverflow.com/questions/5836273/reading-xml-responses-from-google-calendar-service-with-java
